### PR TITLE
refactored exports.handler with Promise.allSettled

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,5 +23,6 @@ exports.handler = async (event) => {
     }
   });
 
-  targets.forEach((target) => target.send());
+  const results = await Promise.allSettled(targets.map((target) => target.send()));
+  console.log('Notification Results: ', results);
 };


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>

With three separate notification calls (email, slack, discord) I started noticing that the slack and discord messages would arrive at their destinations at a strange, delayed cadence, and sometimes they would not arrive at all. 

Checking the logs, this kept popping up:

 > 2022-07-22T21:02:17.122Z	ad16762a-fde9-47c1-b558-d1f2459c9575	ERROR	AXIOS ERROR:  AxiosError: Client network socket disconnected before secure TLS connection was established

After researching I believe the problem was that using a `forEach` loop to *sequentially* call the `send` method on each channel client resulted in network timeouts. Replacing `forEach` with `Promise.allSettled` introduced parallel processing of the requests and eliminated the Axios error.
